### PR TITLE
Tests with Go 1.18

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        go-version: [ 1.14.x, 1.15.x, 1.16.x, 1.17.x ]
+        go-version: [ 1.14.x, 1.15.x, 1.16.x, 1.17.x, 1.18.x ]
 
     name: Tests - Go ${{ matrix.go-version }}
 


### PR DESCRIPTION
This PR ensures tests are also run for the newly released 1.18 version.