### PR TITLE
Update module path to v2 and fix import paths in examples

### DIFF
--- a/cmd/treblle-go/main.go
+++ b/cmd/treblle-go/main.go
@@ -4,7 +4,7 @@ import (
 	"flag"
 	"fmt"
 
-	"github.com/treblle/treblle-go"
+	"github.com/Treblle/treblle-go/v2"
 )
 
 func main() {

--- a/examples/gorilla_example/go.mod
+++ b/examples/gorilla_example/go.mod
@@ -1,12 +1,12 @@
-module example
+module github.com/Treblle/treblle-go/examples/gorilla_example
 
-go 1.23.2
-
-replace github.com/Treblle/treblle-go => /Users/pratimbhosale/Desktop/hobbyprojects/treblle-go
+go 1.21
 
 require (
-	github.com/Treblle/treblle-go v0.0.0-00010101000000-000000000000
+	github.com/Treblle/treblle-go/v2 v2.0.0
 	github.com/gorilla/mux v1.8.1
 )
 
 require golang.org/x/sync v0.11.0 // indirect
+
+replace github.com/Treblle/treblle-go/v2 => ../../

--- a/examples/gorilla_example/main.go
+++ b/examples/gorilla_example/main.go
@@ -7,7 +7,7 @@ import (
 	"log"
 	"net/http"
 
-	treblle "github.com/Treblle/treblle-go" // Update this to your actual import path
+	treblle "github.com/Treblle/treblle-go/v2" // Updated to v2 path
 	"github.com/gorilla/mux"
 )
 

--- a/examples/standard_example/go.mod
+++ b/examples/standard_example/go.mod
@@ -1,9 +1,9 @@
-module standard_example
+module github.com/Treblle/treblle-go/examples/standard_example
 
-go 1.23.2
+go 1.21
 
-replace github.com/Treblle/treblle-go => /Users/pratimbhosale/Desktop/hobbyprojects/treblle-go
+require github.com/Treblle/treblle-go/v2 v2.0.0
 
-require github.com/Treblle/treblle-go v0.0.0-00010101000000-000000000000
+replace github.com/Treblle/treblle-go/v2 => ../../
 
 require golang.org/x/sync v0.11.0 // indirect

--- a/examples/standard_example/main.go
+++ b/examples/standard_example/main.go
@@ -6,7 +6,7 @@ import (
 	"net/http"
 	"strings"
 
-	treblle "github.com/Treblle/treblle-go" // Update this to your actual import path
+	treblle "github.com/Treblle/treblle-go/v2" // Updated to v2 path
 )
 
 type User struct {

--- a/examples/test_cli/main.go
+++ b/examples/test_cli/main.go
@@ -12,7 +12,7 @@ import (
 	"time"
 
 	"github.com/go-chi/chi"
-	"github.com/treblle/treblle-go"
+	"github.com/Treblle/treblle-go/v2"
 )
 
 // Create a test request and response for debugging

--- a/examples/treblle-go-sdk-example/go.mod
+++ b/examples/treblle-go-sdk-example/go.mod
@@ -1,13 +1,15 @@
-module ngroktest
+module github.com/Treblle/treblle-go/examples/treblle-go-sdk-example
 
-go 1.23.2
+go 1.23.0
+
+toolchain go1.23.2
 
 require (
+	github.com/Treblle/treblle-go/v2 v2.0.0
 	github.com/gorilla/mux v1.8.1
 	github.com/joho/godotenv v1.5.1
-	github.com/treblle/treblle-go v0.7.2
 )
 
 require golang.org/x/sync v0.12.0 // indirect
 
-replace github.com/treblle/treblle-go => github.com/timpratim/treblle-go v0.0.0-20250325145413-71c3af83a8c4
+replace github.com/Treblle/treblle-go/v2 => ../../

--- a/examples/treblle-go-sdk-example/go.sum
+++ b/examples/treblle-go-sdk-example/go.sum
@@ -10,8 +10,6 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
-github.com/timpratim/treblle-go v0.0.0-20250325145413-71c3af83a8c4 h1:TBn2cAFZihSgWHXcPv1q69DsEe//pNND6lAXVMdQw78=
-github.com/timpratim/treblle-go v0.0.0-20250325145413-71c3af83a8c4/go.mod h1:zIneSfxSc9ob2HEGrzx4fpjMff1WpEtniAkYaGrijCU=
 golang.org/x/sync v0.12.0 h1:MHc5BpPuC30uJk597Ri8TV3CNZcTLu6B6z4lJy+g6Jw=
 golang.org/x/sync v0.12.0/go.mod h1:1dzgHSNfp02xaA81J2MS99Qcpr2w7fw1gpm99rleRqA=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/examples/treblle-go-sdk-example/main.go
+++ b/examples/treblle-go-sdk-example/main.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/gorilla/mux"
 	"github.com/joho/godotenv"
-	treblle "github.com/treblle/treblle-go"
+	treblle "github.com/Treblle/treblle-go/v2"
 )
 
 type User struct {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/treblle/treblle-go
+module github.com/Treblle/treblle-go/v2
 
 go 1.21
 


### PR DESCRIPTION
Update module path to v2 and fix import paths in examples